### PR TITLE
Synchronize weapon selector between menus

### DIFF
--- a/game_emoji_war/index.html
+++ b/game_emoji_war/index.html
@@ -343,19 +343,20 @@
   <script src="js/game.js"></script>
     <script>
       (function(){
-        const weaponSelect = document.getElementById("weaponSelectBar");
+        const weaponSelectBar = document.getElementById("weaponSelectBar");
         let weaponSelectInterval = null;
-      
+
       function changeWeaponSelection(direction) {
-        let currentIndex = weaponSelect.selectedIndex;
+        let currentIndex = weaponSelectBar.selectedIndex;
         let newIndex = currentIndex + direction;
-        const optionsCount = weaponSelect.options.length;
+        const optionsCount = weaponSelectBar.options.length;
         if (newIndex < 0) newIndex = optionsCount - 1;
         if (newIndex >= optionsCount) newIndex = 0;
-        weaponSelect.selectedIndex = newIndex;
+        weaponSelectBar.selectedIndex = newIndex;
+        weaponSelectBar.dispatchEvent(new Event("change"));
       }
-      
-      weaponSelect.addEventListener("keydown", function(e) {
+
+      weaponSelectBar.addEventListener("keydown", function(e) {
         if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
           e.preventDefault();
           changeWeaponSelection(e.key === "ArrowLeft" ? -1 : 1);
@@ -366,15 +367,15 @@
           }
         }
       });
-      
-      weaponSelect.addEventListener("keyup", function(e) {
+
+      weaponSelectBar.addEventListener("keyup", function(e) {
         if (e.key === "ArrowLeft" || e.key === "ArrowRight") {
           clearInterval(weaponSelectInterval);
           weaponSelectInterval = null;
         }
       });
-      
-      weaponSelect.addEventListener("blur", function(){
+
+      weaponSelectBar.addEventListener("blur", function(){
         clearInterval(weaponSelectInterval);
         weaponSelectInterval = null;
       });

--- a/game_emoji_war/js/game.js
+++ b/game_emoji_war/js/game.js
@@ -276,6 +276,7 @@ mouse.element.addEventListener("mousewheel", function(e) {
 
 // Weapon selection and firing UI elements
 const weaponSelect = document.getElementById('weaponSelect');
+const weaponSelectBar = document.getElementById('weaponSelectBar');
 const fireButton = document.getElementById('fireButton');
 const weaponDamageIndicator = document.getElementById('weaponDamage');
 const activeTeamIndicator = document.getElementById('activeTeam');
@@ -288,6 +289,12 @@ weaponSelect.addEventListener('change', () => {
   const selectedWeapon = weaponSelect.value;
   weaponDamageIndicator.textContent = `Damage: ${weaponDamage[selectedWeapon]}`;
 });
+if (weaponSelectBar) {
+  weaponSelectBar.addEventListener('change', () => {
+    weaponSelect.value = weaponSelectBar.value;
+    weaponDamageIndicator.textContent = `Damage: ${weaponDamage[weaponSelect.value]}`;
+  });
+}
 fireButton.addEventListener('mousedown', () => {
   if (weaponSelect.value === 'apple' || weaponSelect.value === 'banana') {
     if (!isCharging) {
@@ -429,8 +436,10 @@ on(Actions.CHANGE_WEAPON, () => {
   let nextIndex = (currentIndex + 1) % weaponSelect.options.length;
   weaponSelect.selectedIndex = nextIndex;
   weaponDamageIndicator.textContent = `Damage: ${weaponDamage[weaponSelect.value]}`;
-  let weaponSelectBar = document.getElementById("weaponSelectBar");
-  if (weaponSelectBar) weaponSelectBar.selectedIndex = nextIndex;
+  if (weaponSelectBar) {
+    weaponSelectBar.selectedIndex = nextIndex;
+    weaponSelectBar.dispatchEvent(new Event('change'));
+  }
 });
 
 // 


### PR DESCRIPTION
## Summary
- Synchronize weapon selection between primary menu and touch bar by adding global `weaponSelectBar` and change listener
- Update touch bar script to dispatch change events so both menus show same weapon and damage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898980482d8832e9140f2618b3f02bf